### PR TITLE
settings: TAGGIT_AUTOSUGGEST_SELECT2_EXTRA_SETTINGS / TAGGIT_AUTOSUGGEST_SELECT2_LOAD_SELECT2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This project is directly based on those projects:
 
 
 ## Settings
+* `TAGGIT_AUTOSUGGEST_SELECT2_LOAD_SELECT2` (Defaults to True)
+    Set to False if you don't want the widget to load select2 libraries.
+    (useful if it is already loaded).
 * `TAGGIT_AUTOSUGGEST_SELECT2_STATIC_BASE_URL`
     Instead of collecting and serving the static files directly, you can
     also set this variable to your static base URL somewhere else.

--- a/README.txt
+++ b/README.txt
@@ -16,6 +16,7 @@ This project is directly based on those projects:
     * http://code.drewwilson.com/entry/autosuggest-jquery-plugin
 
 ## Installation
+* If django-taggit isn't installed yet, add 'taggit' to your INSTALLED_APPS in your project settings
 * Add "taggit_autosuggest_select2" to your INSTALLED_APPS in your project settings
 * Run "python manage.py collectstatic" in your django site dir.
 * Add the following line to your project's urls.py file:
@@ -23,6 +24,9 @@ This project is directly based on those projects:
 
 
 ## Settings
+* `TAGGIT_AUTOSUGGEST_SELECT2_LOAD_SELECT2` (Defaults to True)
+    Set to False if you don't want the widget to load select2 libraries.
+    (useful if it is already loaded).
 * `TAGGIT_AUTOSUGGEST_SELECT2_STATIC_BASE_URL`
     Instead of collecting and serving the static files directly, you can
     also set this variable to your static base URL somewhere else.

--- a/taggit_autosuggest_select2/widgets.py
+++ b/taggit_autosuggest_select2/widgets.py
@@ -14,6 +14,7 @@ json_encode = json.JSONEncoder().encode
 
 MAX_SUGGESTIONS = getattr(settings, 'TAGGIT_AUTOSUGGEST_SELECT2_MAX_SUGGESTIONS', 20)
 EXTRA_SETTINGS = getattr(settings, 'TAGGIT_AUTOSUGGEST_SELECT2_EXTRA_SETTINGS',{})
+LOAD_SELECT2 = getattr(settings, 'TAGGIT_AUTOSUGGEST_SELECT2_LOAD_SELECT2', True)
 
 class TagAutoSuggest(forms.TextInput):
     input_type = 'text'
@@ -61,8 +62,9 @@ class TagAutoSuggest(forms.TextInput):
         return result_html + widget_html + mark_safe(js)
 
     class Media:
-        js_base_url = getattr(settings, 'TAGGIT_AUTOSUGGEST_SELECT2_STATIC_BASE_URL', '%s' % settings.STATIC_URL)
-        select2_css_url = getattr(settings,'TAGGIT_AUTOSUGGEST_SELECT2_CSS_URL','%scss/select2.css' % js_base_url)
-        select2_js_url = getattr(settings,'TAGGIT_AUTOSUGGEST_SELECT2_JS_URL','%sjs/select2.min.js' % js_base_url)
-        css = {'all': (select2_css_url,)}
-        js = (select2_js_url,)
+        if LOAD_SELECT2:
+            js_base_url = getattr(settings, 'TAGGIT_AUTOSUGGEST_SELECT2_STATIC_BASE_URL', '%s' % settings.STATIC_URL)
+            select2_css_url = getattr(settings,'TAGGIT_AUTOSUGGEST_SELECT2_CSS_URL','%scss/select2.css' % js_base_url)
+            select2_js_url = getattr(settings,'TAGGIT_AUTOSUGGEST_SELECT2_JS_URL','%sjs/select2.min.js' % js_base_url)
+            css = {'all': (select2_css_url,)}
+            js = (select2_js_url,)

--- a/taggit_autosuggest_select2/widgets.py
+++ b/taggit_autosuggest_select2/widgets.py
@@ -13,7 +13,7 @@ json_encode = json.JSONEncoder().encode
 
 
 MAX_SUGGESTIONS = getattr(settings, 'TAGGIT_AUTOSUGGEST_SELECT2_MAX_SUGGESTIONS', 20)
-EXTRA_SETTINGS = getattr(settings, 'TAGGIT_AUTOSUGGES_SELECT2_EXTRA_SETTINGS',{})
+EXTRA_SETTINGS = getattr(settings, 'TAGGIT_AUTOSUGGEST_SELECT2_EXTRA_SETTINGS',{})
 
 class TagAutoSuggest(forms.TextInput):
     input_type = 'text'


### PR DESCRIPTION
fix typo in setting widgets.py#L16: TAGGIT_AUTOSUGGES_SELECT2_EXTRA_SETTINGS > TAGGIT_AUTOSUGGEST_SELECT2_EXTRA_SETTINGS
Added extra setting TAGGIT_AUTOSUGGEST_SELECT2_LOAD_SELECT2  to avoid loading select2 (in case it's already loaded)